### PR TITLE
bugfix: node-mcrypt is not 100% compatible with php-mcrypt

### DIFF
--- a/modules/algorithms/blowfish.c
+++ b/modules/algorithms/blowfish.c
@@ -419,7 +419,7 @@ static const word32 pi[] = {
 };
 
 
-static short initialize_blowfish(blf_ctx * c, char key[],
+static short initialize_blowfish(blf_ctx * c, unsigned char key[],
 				 short keybytes)
 {
 	short i, j;
@@ -474,7 +474,7 @@ static short initialize_blowfish(blf_ctx * c, char key[],
 
 WIN32DLL_DEFINE int _mcrypt_set_key(blf_ctx * c, char *k, int len)
 {
-	initialize_blowfish(c, k, len);
+	initialize_blowfish(c, (unsigned char *)k, len);
 	return 0;
 }
 
@@ -509,8 +509,8 @@ return "Blowfish";
 WIN32DLL_DEFINE int _mcrypt_self_test()
 {
 	char *keyword;
-	char plaintext[16];
-	char ciphertext[16];
+	unsigned char plaintext[16];
+	unsigned char ciphertext[16];
 	int blocksize = _mcrypt_get_block_size(), j;
 	void *key;
 	unsigned char cipher_tmp[200];
@@ -552,7 +552,7 @@ WIN32DLL_DEFINE int _mcrypt_self_test()
 	_mcrypt_decrypt(key, (void *) ciphertext);
 	free(key);
 
-	if (strcmp(ciphertext, plaintext) != 0) {
+	if (strcmp((const char *)ciphertext, (const char *)plaintext) != 0) {
 		printf("failed internally\n");
 		return -1;
 	}


### PR DESCRIPTION
because of the data type in-consistency when encrypting in this lib, different results were produced when compared to php.

Env to reproduce the bug:

```
uname -a # Darwin MacBook-Pro-2.local 16.1.0 Darwin Kernel Version 16.1.0: Thu Oct 13 21:26:57 PDT 2016; root:xnu-3789.21.3~60/RELEASE_X86_64 x86_64
node -v # v7.1.0
npm -v # v3.10.9
```

Code to reproduce the bug:

```php
define('SECRET', '23iu4sdkfjkweru');

function encrypt($id) {
    $key = md5(SECRET, true);
    $data = mcrypt_encrypt(MCRYPT_BLOWFISH, $key, $id, 'ecb');
    $data = bin2hex($data);

    return $data;
}

$text = '1165096';
echo 'raw:', $text, PHP_EOL;
echo 'encrypted:', encrypt($text), PHP_EOL;
```

which outputs:

```
raw:1165096
encrypted:2d1a3b0fe553c55c
```

same logic in nodejs:

```javascript
const MCrypt = require('mcrypt').MCrypt;
const crypto = require('crypto');
const bin2hex = require('locutus/php/strings/bin2hex');

const secret = '23iu4sdkfjkweru';

const key = crypto.createHash('md5').update(secret).digest();

const encrypt = function(id) {
	const engine = new MCrypt('blowfish', 'ecb');
	engine.validateKeySize(false);
	engine.open(key);

	const data = id.toString();
	const buffer = Buffer.alloc(data.length);
	buffer.write(data);

	const encrypted = engine.encrypt(buffer);
	return bin2hex(encrypted.toString('binary'));
};

const text = '1165096';
console.log('test.js: raw', text);
console.log('test.js: encrypted', encrypt(text));
```

which outputs:

```
test.js: raw 1165096
test.js: encrypted 74a415a65f0713b8
```

